### PR TITLE
feat: support Router to get FunctionDescriptor from HTTPRequest

### DIFF
--- a/thrift/idl.go
+++ b/thrift/idl.go
@@ -440,7 +440,6 @@ func addFunction(fn *parser.Function, tree *parser.Thrift, sDsc *ServiceDescript
 	copyAnnotationValues(fnDsc.annotations, fn.Annotations)
 
 	for _, ann := range fn.Annotations {
-		fmt.Println(ann)
 		if nr, ok := AnnoToRoute(ann.GetKey()); ok {
 			for _, v := range ann.GetValues() {
 				sDsc.Router.Handle(nr(v, fnDsc))

--- a/thrift/idl_test.go
+++ b/thrift/idl_test.go
@@ -165,6 +165,7 @@ func TestRouterLookup(t *testing.T) {
 		Request: hr,
 	}
 	fnDsc, err := svc.Router.Lookup(req)
+	require.Equal(t, err, nil)
 	require.Equal(t, fnDsc.name, "ExampleMethod")
 }
 

--- a/thrift/router.go
+++ b/thrift/router.go
@@ -81,14 +81,11 @@ func (r *router) Handle(rt Route) {
 }
 
 func (r *router) Lookup(req *http.HTTPRequest) (*FunctionDescriptor, error) {
-	fmt.Println(req.Method())
 	root, ok := r.trees[req.Method()]
-	fmt.Println(root)
 	if !ok {
 		return nil, fmt.Errorf("function lookup failed, no root with method=%s", req.Method())
 	}
 	fn, ps, _ := root.getValue(req.Path(), r.getParams, false)
-	fmt.Println(req.Path(), fn, ps)
 	if fn == nil {
 		r.putParams(ps)
 		return nil, fmt.Errorf("function lookup failed, path=%s", req.Path())


### PR DESCRIPTION
#### What type of PR is this?
feat
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### What this PR does / why we need it (en: English/zh: Chinese):
<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->
en: Kitex generic call wants to integrate dynamicgo and needs to get FunctionDescriptor from HTTPRequest.
zh:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
