### PR TITLE
feat:(conv) add fallback options for http-mapping

### DIFF
--- a/conv/api.go
+++ b/conv/api.go
@@ -48,30 +48,32 @@ var (
 )
 
 type Options struct {
-	// DisallowUnknownField indicates if unknown fields should be skipped
-	DisallowUnknownField bool
-	// WriteDefaultField indicates if default-requireness fields should be written if
-	WriteDefaultField bool
+	
 	// EnableValueMapping indicates if value mapping (api.js_conv...) should be enabled
 	EnableValueMapping bool
 	// EnableHttpMapping indicates if http mapping (api.query|api.header...) should be enabled
 	EnableHttpMapping bool
 	// EnableThriftBase indicates if thrift/base should be recoginized and mapping to/from context
 	EnableThriftBase bool
-	// UseNativeSkip indicates if use thrift.SkipNative() or thrift.SkipGo()
-	UseNativeSkip bool
+	
 	// Int64AsString indicates if string value cane be read as **Int8/Int16/Int32/Int64/Float64**,
 	// or in response a **Int64** value can be written as string
 	String2Int64 bool
-	// WriteRequireField indicates if required-requireness fields should be written empty value if
-	// not found
-	WriteRequireField bool
 	// NoBase64Binary indicates if base64 string shoud be Encode/Decode as []byte
 	NoBase64Binary bool
 	// ByteAsUint8 indicates if byte should be conv as uint8 (default is int8), this only works for t2j now
 	ByteAsUint8 bool
+
 	// WriteOptionalField indicates if optional-requireness fields should be written when not given
 	WriteOptionalField bool
+	// WriteDefaultField indicates if default-requireness fields should be written if
+	WriteDefaultField bool
+	// WriteRequireField indicates if required-requireness fields should be written empty value if
+	// not found
+	WriteRequireField bool
+	// DisallowUnknownField indicates if unknown fields should be skipped
+	DisallowUnknownField bool
+	
 	// ReadHttpValueFallback indicates if http-annotated fields should fallback to http body after reading from non-body parts (header,cookie...) failed
 	ReadHttpValueFallback bool
 	// WriteHttpValueFallback indicates if http-annotated fields should fallback to http body after writing to non-body parts (header,cookie...) failed
@@ -80,10 +82,15 @@ type Options struct {
 	// or root-level fields should be seeking on http-values when reading failed from current layer of json.
 	// this option is only used in j2t now.
 	TracebackRequredOrRootFields bool
+	// OmitHttpMappingErrors indicates to omit http-mapping failing errors. 
+	// If there are more-than-one HTTP annotations on the field, dynamicgo will try to mapping next annotation source (from left to right) until succeed.
+	OmitHttpMappingErrors bool
+	
 	// NoCopyString indicates if string-kind http values should be copied or just referenced (if possible)
 	NoCopyString bool
-	// OmitHttpMappingErrors indicates if dynamicgo should not return error when any http-mapping failed
-	OmitHttpMappingErrors bool
+	// UseNativeSkip indicates if use thrift.SkipNative() or thrift.SkipGo()
+	UseNativeSkip bool
+	
 }
 
 var bufPool = sync.Pool{

--- a/conv/api.go
+++ b/conv/api.go
@@ -82,6 +82,8 @@ type Options struct {
 	TracebackRequredOrRootFields bool
 	// NoCopyString indicates if string-kind http values should be copied or just referenced (if possible)
 	NoCopyString bool
+	// OmitHttpMappingErrors indicates if dynamicgo should not return error when any http-mapping failed
+	OmitHttpMappingErrors bool
 }
 
 var bufPool = sync.Pool{

--- a/conv/api.go
+++ b/conv/api.go
@@ -72,15 +72,15 @@ type Options struct {
 	ByteAsUint8 bool
 	// WriteOptionalField indicates if optional-requireness fields should be written when not given
 	WriteOptionalField bool
+	// ReadHttpValueFallback indicates if http-annotated fields should fallback to http body after reading from non-body parts (header,cookie...) failed
+	ReadHttpValueFallback bool
+	// WriteHttpValueFallback indicates if http-annotated fields should fallback to http body after writing to non-body parts (header,cookie...) failed
+	WriteHttpValueFallback bool
 	// TracebackRequredOrRootFields indicates if required-requireness
 	// or root-level fields should be seeking on http-values when reading failed from current layer of json.
 	// this option is only used in j2t now.
 	TracebackRequredOrRootFields bool
-	// WriteHttpValueFallback indicates if continue writing the field into json after mapping to http response failed
-	WriteHttpValueFallback bool
-	// ReadHttpValueFallback indicates if continue reading the field from json after mapping from http request failed
-	ReadHttpValueFallback bool
-	// NoCopyString indicates if string should be copied or just referenced (if possible)
+	// NoCopyString indicates if string-kind http values should be copied or just referenced (if possible)
 	NoCopyString bool
 }
 

--- a/conv/api.go
+++ b/conv/api.go
@@ -56,8 +56,6 @@ type Options struct {
 	EnableValueMapping bool
 	// EnableHttpMapping indicates if http mapping (api.query|api.header...) should be enabled
 	EnableHttpMapping bool
-	// HttpMappingAsExtra indicates if continuing convert the same field after http mapping
-	HttpMappingAsExtra bool
 	// EnableThriftBase indicates if thrift/base should be recoginized and mapping to/from context
 	EnableThriftBase bool
 	// UseNativeSkip indicates if use thrift.SkipNative() or thrift.SkipGo()
@@ -78,6 +76,10 @@ type Options struct {
 	// or root-level fields should be seeking on http-values when reading failed from current layer of json.
 	// this option is only used in j2t now.
 	TracebackRequredOrRootFields bool
+	// WriteHttpValueFallback indicates if continue writing the field into json after mapping to http response failed
+	WriteHttpValueFallback bool
+	// ReadHttpValueFallback indicates if continue reading the field from json after mapping from http request failed
+	ReadHttpValueFallback bool
 	// NoCopyString indicates if string should be copied or just referenced (if possible)
 	NoCopyString bool
 }

--- a/conv/j2t/conv.go
+++ b/conv/j2t/conv.go
@@ -123,7 +123,7 @@ func toFlags(opts conv.Options) (flags uint64) {
 	if opts.WriteOptionalField {
 		flags |= types.F_WRITE_OPTIONAL
 	}
-	if opts.TracebackRequredOrRootFields {
+	if opts.ReadHttpValueFallback {
 		flags |= types.F_TRACE_BACK
 	}
 	return

--- a/conv/j2t/conv_test.go
+++ b/conv/j2t/conv_test.go
@@ -371,8 +371,9 @@ func TestBodyFallbackToHttp(t *testing.T) {
 		err = json.Unmarshal(edata, exp)
 		require.Nil(t, err)
 		cv := NewBinaryConv(conv.Options{
-			EnableHttpMapping:            true,
-			WriteDefaultField:            true,
+			EnableHttpMapping:     true,
+			WriteDefaultField:     true,
+			ReadHttpValueFallback: true,
 			TracebackRequredOrRootFields: true,
 		})
 		ctx := context.Background()
@@ -392,9 +393,10 @@ func TestBodyFallbackToHttp(t *testing.T) {
 		err = json.Unmarshal(edata, exp)
 		require.Nil(t, err)
 		cv := NewBinaryConv(conv.Options{
-			WriteRequireField:            true,
-			EnableHttpMapping:            true,
-			WriteDefaultField:            false,
+			WriteRequireField:     true,
+			EnableHttpMapping:     true,
+			WriteDefaultField:     false,
+			ReadHttpValueFallback: true,
 			TracebackRequredOrRootFields: true,
 		})
 		ctx := context.Background()
@@ -452,8 +454,9 @@ func TestApiBody(t *testing.T) {
 	desc := getExampleDescByName("ApiBodyMethod", true, thrift.Options{})
 	data := []byte(`{"code":1024,"InnerCode":{}}`)
 	cv := NewBinaryConv(conv.Options{
-		EnableHttpMapping:            true,
-		WriteDefaultField:            true,
+		EnableHttpMapping:     true,
+		WriteDefaultField:     true,
+		ReadHttpValueFallback: true,
 		TracebackRequredOrRootFields: true,
 	})
 	ctx := context.Background()
@@ -764,6 +767,7 @@ func TestStateMachineOOM(t *testing.T) {
 		cv := NewBinaryConv(conv.Options{
 			EnableHttpMapping:            true,
 			WriteRequireField:            true,
+			ReadHttpValueFallback: true,
 			TracebackRequredOrRootFields: true,
 		})
 		ctx := context.Background()
@@ -1000,7 +1004,7 @@ func TestHttpMappingFallback(t *testing.T) {
 		}
 		cv := NewBinaryConv(conv.Options{
 			EnableHttpMapping:            true,
-			TracebackRequredOrRootFields: true,
+			ReadHttpValueFallback: true,
 		})
 		ctx := context.Background()
 		ctx = context.WithValue(ctx, conv.CtxKeyHTTPRequest, req)
@@ -1056,6 +1060,7 @@ func TestPostFormBody(t *testing.T) {
 		cv := NewBinaryConv(conv.Options{
 			WriteDefaultField:            true,
 			EnableHttpMapping:            true,
+			ReadHttpValueFallback: true,
 			TracebackRequredOrRootFields: true,
 		})
 		ctx := context.Background()
@@ -1116,7 +1121,7 @@ func TestAGWDynamicBody(t *testing.T) {
 			EnableValueMapping:           true,
 			EnableHttpMapping:            false,
 			WriteRequireField:            true,
-			TracebackRequredOrRootFields: true,
+			ReadHttpValueFallback: true,
 		})
 		ctx := context.Background()
 		out, err := cv.Do(ctx, desc, []byte(data))
@@ -1132,6 +1137,7 @@ func TestAGWDynamicBody(t *testing.T) {
 			EnableValueMapping:           true,
 			EnableHttpMapping:            true,
 			WriteRequireField:            true,
+			ReadHttpValueFallback: true,
 			TracebackRequredOrRootFields: true,
 		})
 		ctx := context.Background()
@@ -1172,7 +1178,7 @@ func TestNobodyRequiredFields(t *testing.T) {
 	cv := NewBinaryConv(conv.Options{
 		EnableHttpMapping:            true,
 		WriteRequireField:            true,
-		TracebackRequredOrRootFields: true,
+		ReadHttpValueFallback: true,
 	})
 	ctx := context.Background()
 	req, err := http.NewHTTPRequestFromUrl("GET", "http://localhost?required_field=1", nil)

--- a/conv/j2t/http_conv_test.go
+++ b/conv/j2t/http_conv_test.go
@@ -111,7 +111,7 @@ func TestHTTPConv_Do(t *testing.T) {
 			gotTbytes := make([]byte, 0, 1)
 			err := convIns.DoInto(context.Background(), tt.req, &gotTbytes, conv.Options{
 				WriteRequireField:            true,
-				TracebackRequredOrRootFields: true,
+				ReadHttpValueFallback:        true,
 				EnableHttpMapping:            true,
 			})
 			spew.Dump(gotTbytes)

--- a/conv/j2t/impl.go
+++ b/conv/j2t/impl.go
@@ -57,7 +57,7 @@ func (self *BinaryConv) do(ctx context.Context, src []byte, desc *thrift.TypeDes
 			// check if any required field exists, if have, traceback on http
 			// since this case it always for top-level fields,
 			// we should only check opts.BackTraceRequireOrTopField to decide whether to traceback
-			err := reqs.HandleRequires(st, self.opts.TracebackRequredOrRootFields, self.opts.TracebackRequredOrRootFields, self.opts.TracebackRequredOrRootFields, func(f *thrift.FieldDescriptor) error {
+			err := reqs.HandleRequires(st, self.opts.ReadHttpValueFallback, self.opts.ReadHttpValueFallback, self.opts.ReadHttpValueFallback, func(f *thrift.FieldDescriptor) error {
 				val, _ := tryGetValueFromHttp(req, f.Alias())
 				if err := self.writeStringValue(ctx, buf, f, val, meta.EncodingJSON, req); err != nil {
 					return err
@@ -209,7 +209,7 @@ func (self *BinaryConv) writeHttpRequestToThrift(ctx context.Context, req http.R
 			} else {
 				// NOTICE: if no value found, tracebak on current json layeer to find value
 				// it must be a top level field or required field
-				if self.opts.TracebackRequredOrRootFields && (top || f.Required() == thrift.RequiredRequireness) {
+				if self.opts.ReadHttpValueFallback {
 					reqs.Set(f.ID(), thrift.RequiredRequireness)
 					continue
 				}

--- a/conv/t2j/conv_amd64_test.go
+++ b/conv/t2j/conv_amd64_test.go
@@ -37,6 +37,7 @@ func TestConvThrift2HTTP(t *testing.T) {
 		// MapRecurseDepth:    conv.DefaultMaxDepth,
 		EnableValueMapping: true,
 		EnableHttpMapping:  true,
+		OmitHttpMappingErrors: true,
 	})
 	in := getExample3Data()
 	ctx := context.Background()

--- a/conv/t2j/conv_fallback_test.go
+++ b/conv/t2j/conv_fallback_test.go
@@ -37,6 +37,7 @@ func TestConvThrift2HTTP(t *testing.T) {
 		// MapRecurseDepth:    conv.DefaultMaxDepth,
 		EnableValueMapping: true,
 		EnableHttpMapping:  true,
+		OmitHttpMappingErrors: true,
 	})
 	in := getExample3Data()
 	ctx := context.Background()

--- a/conv/t2j/conv_test.go
+++ b/conv/t2j/conv_test.go
@@ -325,6 +325,7 @@ func TestHttpMappingFallback(t *testing.T) {
 		cv.SetOptions(conv.Options{
 			EnableHttpMapping:  true,
 			WriteHttpValueFallback: false,
+			OmitHttpMappingErrors: true,
 		})
 		ctx := context.Background()
 		resp := http.NewHTTPResponse()
@@ -347,6 +348,7 @@ func TestHttpMappingFallback(t *testing.T) {
 		cv.SetOptions(conv.Options{
 			EnableHttpMapping:  true,
 			WriteHttpValueFallback: true,
+			OmitHttpMappingErrors: true,
 		})
 		ctx := context.Background()
 		resp := http.NewHTTPResponse()
@@ -510,6 +512,7 @@ func TestJSONString(t *testing.T) {
 	cv := NewBinaryConv(conv.Options{
 		EnableHttpMapping: true,
 		WriteHttpValueFallback: true,
+		OmitHttpMappingErrors: true,
 	})
 	ctx := context.Background()
 	resp := http.NewHTTPResponse()

--- a/conv/t2j/conv_test.go
+++ b/conv/t2j/conv_test.go
@@ -321,10 +321,10 @@ func TestHttpMappingFallback(t *testing.T) {
 		exp.Heeader = "world"
 		in := make([]byte, exp.BLength())
 		_ = exp.FastWriteNocopy(in, nil)
-		expJSON := `{"Msg":"hello"}`
+		expJSON := `{}`
 		cv.SetOptions(conv.Options{
 			EnableHttpMapping:  true,
-			HttpMappingAsExtra: false,
+			WriteHttpValueFallback: false,
 		})
 		ctx := context.Background()
 		resp := http.NewHTTPResponse()
@@ -343,10 +343,10 @@ func TestHttpMappingFallback(t *testing.T) {
 		exp.Heeader = "world"
 		in := make([]byte, exp.BLength())
 		_ = exp.FastWriteNocopy(in, nil)
-		expJSON := `{"Msg":"hello","Heeader":"world"}`
+		expJSON := `{"Msg":"hello"}`
 		cv.SetOptions(conv.Options{
 			EnableHttpMapping:  true,
-			HttpMappingAsExtra: true,
+			WriteHttpValueFallback: true,
 		})
 		ctx := context.Background()
 		resp := http.NewHTTPResponse()
@@ -509,6 +509,7 @@ func TestJSONString(t *testing.T) {
 
 	cv := NewBinaryConv(conv.Options{
 		EnableHttpMapping: true,
+		WriteHttpValueFallback: true,
 	})
 	ctx := context.Background()
 	resp := http.NewHTTPResponse()

--- a/conv/t2j/conv_timing_test.go
+++ b/conv/t2j/conv_timing_test.go
@@ -48,6 +48,7 @@ func BenchmarkThrift2HTTP_DynamicGo(b *testing.B) {
 	conv := NewBinaryConv(conv.Options{
 		EnableValueMapping: true,
 		EnableHttpMapping:  true,
+		OmitHttpMappingErrors: true,
 	})
 	in := getExample3Data()
 	ctx := context.Background()

--- a/conv/t2j/impl.go
+++ b/conv/t2j/impl.go
@@ -122,8 +122,9 @@ func (self *BinaryConv) do(ctx context.Context, src []byte, desc *thrift.TypeDes
 			if err != nil {
 				return unwrapError(fmt.Sprintf("mapping field %d of STRUCT %s failed", field.ID(), desc.Name()), err)
 			}
-			// NOTICE: if no mapping success, we ignore option HttpMappingAsExtra and continue to write to json body
-			if !self.opts.HttpMappingAsExtra && ok {
+			// NOTICE: if option HttpMappingAsExtra is false and http-mapping failed,
+			// continue to write to json body
+			if !self.opts.WriteHttpValueFallback || ok {
 				continue
 			}
 		}
@@ -262,8 +263,9 @@ func (self *BinaryConv) doRecurse(ctx context.Context, desc *thrift.TypeDescript
 				if err != nil {
 					return unwrapError(fmt.Sprintf("mapping field %d of STRUCT %s failed", field.ID(), desc.Name()), err)
 				}
-				// NOTICE: if no mapping success, we ignore option HttpMappingAsExtra and continue to write to json body
-				if !self.opts.HttpMappingAsExtra && ok {
+				// NOTICE: if option HttpMappingAsExtra is false and http-mapping failed,
+				// continue to write to json body
+				if !self.opts.WriteHttpValueFallback || ok {
 					continue
 				}
 			}

--- a/go.sum
+++ b/go.sum
@@ -77,6 +77,7 @@ github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/chenzhuoyu/base64x v0.0.0-20211019084208-fb5309c8db06/go.mod h1:DH46F32mSOjUmXrMHnKwZdA8wcEefY7UVqBKYGjpdQY=
 github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311 h1:qSGYFH7+jGhDF8vLC+iwCD4WpbV1EBDSzWkJODFLams=
 github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311/go.mod h1:b583jCggY9gE99b6G5LEC39OIiVsWj+R97kbl5odCEk=
+github.com/chenzhuoyu/iasm v0.0.0-20220818063314-28c361dae733 h1:Hx6Jxqln+bHRrtjUdgrehhF3gtWVJ2S7bjO/YTNn8Fg=
 github.com/chenzhuoyu/iasm v0.0.0-20220818063314-28c361dae733/go.mod h1:wOQ0nsbeOLa2awv8bUYFW/EHXbjQMlZ10fAlXDB2sz8=
 github.com/choleraehyq/pid v0.0.13/go.mod h1:uhzeFgxJZWQsZulelVQZwdASxQ9TIPZYL4TPkQMtL/U=
 github.com/choleraehyq/pid v0.0.15/go.mod h1:uhzeFgxJZWQsZulelVQZwdASxQ9TIPZYL4TPkQMtL/U=
@@ -90,6 +91,7 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/chzyer/test v0.0.0-20210722231415-061457976a23/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudwego/fastpb v0.0.3/go.mod h1:/V13XFTq2TUkxj2qWReV8MwfPC4NnPcy6FsrojnsSG0=
+github.com/cloudwego/frugal v0.1.3 h1:tw3+hh4YMmtHFHRue3OGYjAnkxnZRHqeAyG18+7z5aI=
 github.com/cloudwego/frugal v0.1.3/go.mod h1:b981ViPYdhI56aFYsoMjl9kv6yeqYSO+iEz2jrhkCgI=
 github.com/cloudwego/kitex v0.3.2/go.mod h1:/XD07VpUD9VQWmmoepASgZ6iw//vgWikVA9MpzLC5i0=
 github.com/cloudwego/kitex v0.4.4 h1:/oInvgh0Nz8OpzXBrXkD3qVBkiQmCCdCVLdIpktj6q0=
@@ -159,6 +161,7 @@ github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.1/go.mod h1:DopwsBzvsk0Fs44TXzsVbJyPhcCPeIwnvohx4u74HPM=
+github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
@@ -222,6 +225,7 @@ github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20220319035150-800ac71e25c2/go.mod h1:aYm2/VgdVmcIU8iMfdMvDMsRAQjcfZSKFby6HOFvi/w=
+github.com/jhump/protoreflect v1.8.2 h1:k2xE7wcUomeqwY0LDCYA16y4WWfyTcMx5mKhk0d4ua0=
 github.com/jhump/protoreflect v1.8.2/go.mod h1:7GcYQDdMU/O/BBrl/cX6PNHpXh6cenjd8pneu5yW7Tg=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
@@ -250,6 +254,7 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lN
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/nishanths/predeclared v0.0.0-20200524104333-86fad755b4d3/go.mod h1:nt3d53pc1VYcphSCIaYAJtnPYnr3Zyn8fMq2wvPGPso=
+github.com/oleiade/lane v1.0.1 h1:hXofkn7GEOubzTwNpeL9MaNy8WxolCYb9cInAIeqShU=
 github.com/oleiade/lane v1.0.1/go.mod h1:IyTkraa4maLfjq/GmHR+Dxb4kCMtEGeb+qmhlrQ5Mk4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -273,8 +278,11 @@ github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/thrift-iterator/go v0.0.0-20190402154806-9b5a67519118 h1:MIx5ElxAmfKzHGb3ptBbq9YE3weh55cH1Mb7VA4Oxbg=
 github.com/thrift-iterator/go v0.0.0-20190402154806-9b5a67519118/go.mod h1:60PRwE/TCI1UqLvn8v2pwAf6+yzTPLP/Ji5xaesWDqk=
+github.com/tidwall/gjson v1.9.3 h1:hqzS9wAHMO+KVBBkLxYdkEeeFHuqr95GfClRLKlgK0E=
 github.com/tidwall/gjson v1.9.3/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
 github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
 github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS4MhqMhdFk5YI=
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=

--- a/meta/error.go
+++ b/meta/error.go
@@ -18,6 +18,7 @@ package meta
 
 import (
 	"fmt"
+	"strings"
 )
 
 // CategoryBitOnErrorCode is used to shift category on error code
@@ -117,13 +118,11 @@ func NewError(code ErrCode, msg string, err error) error {
 // Message return current message if has,
 // otherwise return preceding error message
 func (err Error) Message() string {
-	if err.Msg != "" {
-		return err.Msg
-	} else if err.Err != nil {
-		return err.Error()
-	} else {
-		return ""
+	output := []string{err.Msg}
+	if err.Err != nil {
+		output = append(output, err.Err.Error())
 	}
+	return strings.Join(output, "\n")
 }
 
 // Error return error message,

--- a/testdata/baseline_j2t_test.go
+++ b/testdata/baseline_j2t_test.go
@@ -498,6 +498,7 @@ func TestThriftEncodeNesting_Raw(t *testing.T) {
 		EnableHttpMapping:  true,
 		EnableValueMapping: true,
 		TracebackRequredOrRootFields: true,
+		ReadHttpValueFallback: true,
 	})
 	nj := convertI642StringNesting(nestingJSON, true)
 	out, err := cv.Do(ctx, nesting, []byte(nj))

--- a/testdata/baseline_t2j_test.go
+++ b/testdata/baseline_t2j_test.go
@@ -164,6 +164,7 @@ func TestThrift2HTTP_Raw(t *testing.T) {
 		opts := conv.Options{}
 		opts.EnableHttpMapping = true
 		opts.WriteHttpValueFallback = true
+		opts.OmitHttpMappingErrors = true
 
 		ctx := context.Background()
 		resp := http.NewHTTPResponse()

--- a/testdata/baseline_t2j_test.go
+++ b/testdata/baseline_t2j_test.go
@@ -398,6 +398,7 @@ func BenchmarkThrift2HTTP_DynamicGo(t *testing.B) {
 
 		opts := conv.Options{}
 		opts.EnableValueMapping = false
+		opts.OmitHttpMappingErrors = true
 		ctx := context.Background()
 		ctx = context.WithValue(ctx, conv.CtxKeyHTTPResponse, http.NewHTTPResponse())
 		cv := t2j.NewBinaryConv(opts)
@@ -428,6 +429,8 @@ func BenchmarkThrift2HTTP_DynamicGo(t *testing.B) {
 		opts := conv.Options{}
 		opts.EnableHttpMapping = true
 		opts.EnableValueMapping = false
+		opts.OmitHttpMappingErrors = true
+		opts.NoCopyString = true
 
 		ctx := context.Background()
 		resp := http.NewHTTPResponse()
@@ -459,6 +462,8 @@ func BenchmarkThrift2HTTP_DynamicGo(t *testing.B) {
 		opts := conv.Options{}
 		opts.EnableHttpMapping = true
 		opts.EnableValueMapping = true
+		opts.OmitHttpMappingErrors = true
+		opts.NoCopyString = true
 
 		ctx := context.Background()
 		resp := http.NewHTTPResponse()

--- a/testdata/baseline_t2j_test.go
+++ b/testdata/baseline_t2j_test.go
@@ -124,7 +124,7 @@ func TestThrift2HTTP_Raw(t *testing.T) {
 
 		opts := conv.Options{}
 		opts.EnableHttpMapping = true
-		opts.HttpMappingAsExtra = true
+		opts.WriteHttpValueFallback = true
 		ctx := context.Background()
 		ctx = context.WithValue(ctx, conv.CtxKeyHTTPResponse, http.NewHTTPResponse())
 		cv := t2j.NewBinaryConv(opts)
@@ -163,7 +163,7 @@ func TestThrift2HTTP_Raw(t *testing.T) {
 
 		opts := conv.Options{}
 		opts.EnableHttpMapping = true
-		opts.HttpMappingAsExtra = true
+		opts.WriteHttpValueFallback = true
 
 		ctx := context.Background()
 		resp := http.NewHTTPResponse()
@@ -179,12 +179,18 @@ func TestThrift2HTTP_Raw(t *testing.T) {
 		if err := json.Unmarshal(out, v); err != nil {
 			t.Fatal(err)
 		}
-		ls, err := json.Marshal(v.ListI64)
+		dstr := data.String_
+		data.String_ = ""
+		di32 := data.I32
+		data.I32 = 0
+		ls, err := json.Marshal(data.ListI64)
 		require.NoError(t, err)
+		data.ListI64 = nil
+		
 		require.Equal(t, data, v)
+		require.Equal(t, dstr, resp.Header.Get("String"))
+		require.Equal(t, int(di32), resp.StatusCode)
 		require.Equal(t, string(ls), resp.Cookies()[0].Value)
-		require.Equal(t, v.String_, resp.Header.Get("String"))
-		require.Equal(t, int(v.I32), resp.StatusCode)
 
 		opts.EnableValueMapping = true
 		cv = t2j.NewBinaryConv(opts)
@@ -194,10 +200,10 @@ func TestThrift2HTTP_Raw(t *testing.T) {
 		}
 		v = baseline.NewNesting()
 		ret = []byte(convertI642StringNesting(string(ret), false))
-		err = ejson.Unmarshal(ret, v)
+		_ = ejson.Unmarshal(ret, v)
 		require.Equal(t, string(ls), resp.Cookies()[0].Value)
-		require.Equal(t, v.String_, resp.Header.Get("String"))
-		require.Equal(t, int(v.I32), resp.StatusCode)
+		require.Equal(t, dstr, resp.Header.Get("String"))
+		require.Equal(t, int(di32), resp.StatusCode)
 	})
 }
 

--- a/thrift/annotation/key_mapping.go
+++ b/thrift/annotation/key_mapping.go
@@ -59,7 +59,7 @@ func (self keyMappingAnnotation) Make(ctx context.Context, values []parser.Annot
 			case APIKey:
 				return &apiKey{v.Values[0]}, nil
 			default:
-				return nil, errNotImplemented
+				return nil, errNotImplemented("keyMappingAnnotation must have APIKey type")
 			}
 		}
 	}

--- a/thrift/annotation/register.go
+++ b/thrift/annotation/register.go
@@ -17,7 +17,7 @@
 package annotation
 
 import (
-	"errors"
+	"fmt"
 
 	"github.com/cloudwego/dynamicgo/meta"
 	"github.com/cloudwego/dynamicgo/thrift"
@@ -59,8 +59,14 @@ func init() {
 	thrift.RegisterAnnotationMapper(thrift.AnnoScopeField, nameCaseMapper{}, NameCaseKeys...)
 }
 
-var (
-	errNotImplemented = meta.NewError(meta.ErrUnsupportedType, "not implemented annotation", nil)
-	errNotFound = errors.New("not found value for key")
-)
+//go:noline
+func errNotFound(key string, scope string) error {
+	return meta.NewError(meta.ErrNotFound, fmt.Sprintf("not fould %s in %s", key, scope), nil)
+}
+
+//go:noline
+func errNotImplemented(msg string) error {
+	return meta.NewError(meta.ErrUnsupportedType, msg, nil)
+}
+
 

--- a/thrift/annotation/value_mapping.go
+++ b/thrift/annotation/value_mapping.go
@@ -68,13 +68,13 @@ func (self valueMappingAnnotation) Make(ctx context.Context, values []parser.Ann
 	if len(values) != 1 {
 		return nil, fmt.Errorf("valueMappingAnnotation only support one value")
 	}
-	switch self.typ.Type() {
+	switch t := self.typ.Type(); t {
 	case JSConv:
 		return apiJSConv{}, nil
 	case BodyDynamic:
 		return agwBodyDynamic{}, nil
 	default:
-		return nil, errNotImplemented
+		return nil, errNotImplemented(fmt.Sprintf("unsupported type %v of valueMappingAnnotation", t))
 	}
 }
 
@@ -107,7 +107,7 @@ func (m agwBodyDynamic) Write(ctx context.Context, p *thrift.BinaryProtocol, fie
 type apiJSConv struct{}
 
 func (m apiJSConv) Write(ctx context.Context, p *thrift.BinaryProtocol, field *thrift.FieldDescriptor, in []byte) error {
-	return errNotImplemented
+	return errNotImplemented("apiJSConv not support writing")
 }
 
 func (m apiJSConv) Read(ctx context.Context, p *thrift.BinaryProtocol, field *thrift.FieldDescriptor, out *[]byte) error {

--- a/thrift/annotation/value_mapping_test.go
+++ b/thrift/annotation/value_mapping_test.go
@@ -71,7 +71,7 @@ func (self ValueMappingAnnotation2) Make(ctx context.Context, values []parser.An
 	case APIJSConv2:
 		return apiJSConv2{}, nil
 	default:
-		return nil, errNotImplemented
+		return nil, errNotImplemented("error")
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
feat
#### What this PR does / why we need it (en: English/zh: Chinese):
<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->
en: add fallback options for http-mapping
zh: 添加http-mapping失败兜底选项

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
when http-mapping failed on HTTP<>Thrift conversion，fallback to seeking HTTP body according to option:
- `ReadHttpValueFallback`: indicates if http-annotated fields should fallback to http body after reading from non-body parts (header,cookie...) failed
- `WriteHttpValueFallback`: indicates if http-annotated fields should fallback to http body after writing to non-body parts (header,cookie...) failed
- `OmitHttpMappingErrors`: indicates to omit http-mapping failing errors. If there are more-than-one HTTP annotations on the field, dynamicgo will try to mapping next annotation source (from left to right) until succeed.
