### PR TITLE
test: xprintf support for linux x86_64

### DIFF
--- a/native/test/xprintf.h
+++ b/native/test/xprintf.h
@@ -20,6 +20,8 @@
 #ifndef XPRINTF_H
 #define XPRINTF_H
 
+
+#if (defined (__APPLE__) || defined(__MACH__)) && (defined(__x86_64__) || defined(_M_X64))
 static void __attribute__((naked)) write_syscall(const char *s, size_t n)
 {
     asm volatile(
@@ -36,6 +38,27 @@ static void __attribute__((naked)) write_syscall(const char *s, size_t n)
         "retq"
         "\n");
 }
+#elif defined (__linux__) && (defined(__x86_64__) || defined(_M_X64))
+static void __attribute__((naked)) write_syscall(const char *s, size_t n)
+{
+    asm volatile (
+        "movq %rsi, %rdx"
+        "\n"
+        "movq %rdi, %rsi"
+        "\n"
+        "movl $1, %edi"
+        "\n"
+        "movl $1, %eax"
+        "\n"
+        "syscall"
+        "\n"
+        "retq"
+    );
+}       
+#else
+#error syscall conv unsupported
+#endif
+
 
 static void printch(const char ch)
 {


### PR DESCRIPTION
#### What type of PR is this?

test: add xprintf support for linux x86_64

#### What this PR does / why we need it (en: English/zh: Chinese):

en: conditional compilation for `write_syscall`
zh: conditional compilation  为 `write_syscall`

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
