### PR TITLE
fix empty biz body unwrapBinary EOF error

### DIFF
--- a/thrift/binary.go
+++ b/thrift/binary.go
@@ -204,9 +204,13 @@ func (p BinaryProtocol) UnwrapBody() (string, TMessageType, int32, FieldID, []by
 		return name, rTyp, seqID, 0, nil, err
 	}
 	// read the success struct
-	_, _, structID, err := p.ReadFieldBegin()
+	_, typeId, structID, err := p.ReadFieldBegin()
 	if err != nil {
 		return name, rTyp, seqID, structID, nil, err
+	}
+	//empty response
+	if typeId == STOP {
+		return name, rTyp, seqID, structID, []byte{}, nil
 	}
 	// there's alway a struct stop by success struct
 	if p.Read > len(p.Buf)-1 {

--- a/thrift/binary_test.go
+++ b/thrift/binary_test.go
@@ -171,3 +171,25 @@ func TestBinaryProtocol_WriteAny_ReadAny(t *testing.T) {
 		})
 	}
 }
+
+func TestBinaryUnwrap(t *testing.T) {
+	b := BinaryProtocol{
+		Buf:  nil,
+		Read: 0,
+	}
+	var i32 int32 = -2147418110
+	var methodName = "DummyNew"
+	b.WriteI32(i32)
+	b.WriteString(methodName)
+	b.WriteI32(1)
+	b.WriteByte(byte(STOP))
+
+	name, rType, _, _, bs, err := UnwrapBinaryMessage(b.Buf)
+
+	require.Equal(t, bs, []byte{})
+	require.Equal(t, name, methodName)
+	require.Equal(t, rType, REPLY)
+	var nilErr error
+	require.Equal(t, err, nilErr)
+
+}


### PR DESCRIPTION
#### What type of PR is this?
fix: A bug fix, UnwrapBinaryMessage return an EOF error when the biz body is empty

#### (Optional) Translate the PR title into Chinese.
修复空业务body在unwrapBinaryMessage遇到的EOF错误




#### (Optional) Which issue(s) this PR fixes:
Fixes #69 


