### PR TITLE
feat(proto): expose Package for pb Service Descriptor

### DIFF
--- a/conv/j2p/conv_test.go
+++ b/conv/j2p/conv_test.go
@@ -14,13 +14,14 @@ import (
 	"time"
 
 	"github.com/bytedance/sonic/ast"
+	"github.com/stretchr/testify/require"
+	goprotowire "google.golang.org/protobuf/encoding/protowire"
+
 	"github.com/cloudwego/dynamicgo/conv"
 	"github.com/cloudwego/dynamicgo/internal/util_test"
 	"github.com/cloudwego/dynamicgo/proto"
 	"github.com/cloudwego/dynamicgo/testdata/kitex_gen/pb/base"
 	"github.com/cloudwego/dynamicgo/testdata/kitex_gen/pb/example2"
-	"github.com/stretchr/testify/require"
-	goprotowire "google.golang.org/protobuf/encoding/protowire"
 )
 
 var (

--- a/proto/descriptor.go
+++ b/proto/descriptor.go
@@ -171,6 +171,7 @@ type ServiceDescriptor struct {
 	serviceName        string
 	methods            map[string]*MethodDescriptor
 	isCombinedServices bool
+	packageName        string
 }
 
 func (s *ServiceDescriptor) Name() string {
@@ -187,4 +188,8 @@ func (s *ServiceDescriptor) LookupMethodByName(name string) *MethodDescriptor {
 
 func (s *ServiceDescriptor) IsCombinedServices() bool {
 	return s.isCombinedServices
+}
+
+func (s *ServiceDescriptor) PackageName() string {
+	return s.packageName
 }

--- a/proto/idl.go
+++ b/proto/idl.go
@@ -6,10 +6,11 @@ import (
 	"math"
 	"unsafe"
 
-	"github.com/cloudwego/dynamicgo/internal/util"
-	"github.com/cloudwego/dynamicgo/meta"
 	"github.com/jhump/protoreflect/desc"
 	"github.com/jhump/protoreflect/desc/protoparse"
+
+	"github.com/cloudwego/dynamicgo/internal/util"
+	"github.com/cloudwego/dynamicgo/meta"
 )
 
 type compilingInstance struct {
@@ -118,7 +119,8 @@ func parse(ctx context.Context, fileDesc *desc.FileDescriptor, mode meta.ParseSe
 	}
 
 	sDsc := &ServiceDescriptor{
-		methods: map[string]*MethodDescriptor{},
+		methods:     map[string]*MethodDescriptor{},
+		packageName: fileDesc.GetPackage(),
 	}
 
 	structsCache := compilingCache{}

--- a/proto/idl_test.go
+++ b/proto/idl_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/cloudwego/dynamicgo/meta"
 )
 
@@ -107,4 +109,12 @@ func TestIsCombinedServices(t *testing.T) {
 		t.Fatal("must be a combined service")
 	}
 	fmt.Printf("%#v\n", svc)
+}
+
+func TestParsePackageName(t *testing.T) {
+	opts := Options{}
+	importDirs := []string{"../testdata/idl/"}
+	svc, err := opts.NewDescriptorFromPath(context.Background(), "basic_example.proto", importDirs...)
+	require.Nil(t, err, err)
+	require.Equal(t, "pb3", svc.PackageName(), svc.PackageName())
 }


### PR DESCRIPTION
#### What type of PR is this?
feat
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
feat(proto): 让 pb 服务描述符暴露 Package

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
Take the following pb idl as an example:
```
syntax = "proto3";

package a.b.c;

option go_package = "grpc_official_demo/official";

message Request {
  string message = 1;
}

message Response {
  string message = 1;
}

service GRPCEchoService {
  rpc EchoUnary(Request) returns (Response) {}
  rpc EchoClient(stream Request) returns (Response) {}
  rpc EchoServer(Request) returns (stream Response) {}
  rpc EchoBidi(stream Request) returns (stream Response) {}
}
```
To request EchoServer, for a standard gRPC request, “:path” is filled with “/a.b.c.GRPCEchoService/EchoServer” Where “a.b.c” is the Package of the pb idl.
The current Kitex Json2Pb Streaming generic call using dynamicgo does not resolve to the pb idl's Package, the ":path" is filled with "/GRPCEchoService/EchoServer", and there is problem to  access to other official gRPC libraries such as gRPC-python.
zh(optional): 
以下列 pb idl 为例：
```
syntax = "proto3";

package a.b.c;

option go_package = "grpc_official_demo/official";

message Request {
  string message = 1;
}

message Response {
  string message = 1;
}

service GRPCEchoService {
  rpc EchoUnary(Request) returns (Response) {}
  rpc EchoClient(stream Request) returns (Response) {}
  rpc EchoServer(Request) returns (stream Response) {}
  rpc EchoBidi(stream Request) returns (stream Response) {}
}
```
要请求 EchoServer，对于一个标准的 gRPC 请求，":path" 填入的值为 "/a.b.c.GRPCEchoService/EchoServer"。
其中 "a.b.c" 为 pb idl 的 Package。
当前 Kitex Json2Pb Streaming 泛化调用利用 dynamicgo 无法解析到 pb idl 的 Package，":path" 填入的值为 "/GRPCEchoService/EchoServer"，无法访问 gRPC-python 等其他官方 gRPC 库。

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
