### PR TITLE
fix:(t2j) not recursely write empty struct to avoid dead-loop

### DIFF
--- a/.github/workflows/race-test.yml
+++ b/.github/workflows/race-test.yml
@@ -7,7 +7,8 @@ jobs:
     strategy:
       matrix:
         go-version: [1.24.x]
-    runs-on: [ubuntu-24.04-arm, ubuntu-latest]
+        os: [ubuntu-24.04-arm, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
 

--- a/conv/t2j/conv_test.go
+++ b/conv/t2j/conv_test.go
@@ -440,7 +440,6 @@ func TestWriteEmpty(t *testing.T) {
 	assert.Equal(t, &kbase.BaseResp{
 		StatusMessage: "",
 		StatusCode:    0,
-		Extra:         map[string]string{},
 	}, act.BaseResp)
 }
 

--- a/conv/t2j/impl.go
+++ b/conv/t2j/impl.go
@@ -440,16 +440,6 @@ func writeDefaultOrEmpty(field *thrift.FieldDescriptor, out *[]byte) (err error)
 		*out = json.EncodeEmptyObject(*out)
 	case thrift.STRUCT:
 		*out = json.EncodeObjectBegin(*out)
-		for i, field := range field.Type().Struct().Fields() {
-			if i != 0 {
-				*out = json.EncodeObjectComma(*out)
-			}
-			*out = json.EncodeString(*out, field.Alias())
-			*out = json.EncodeObjectColon(*out)
-			if err := writeDefaultOrEmpty(field, out); err != nil {
-				return err
-			}
-		}
 		*out = json.EncodeObjectEnd(*out)
 	default:
 		return wrapError(meta.ErrUnsupportedType, fmt.Sprintf("unknown descriptor type %s", t), nil)


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: `writeDefaultOrEmpty` shouldn't recursively write empty struct's sub fields...
zh(optional): 


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
