### PR TITLE
fix(generic): Correct iteration in GetDescByPath

### DIFF
--- a/thrift/generic/path.go
+++ b/thrift/generic/path.go
@@ -279,6 +279,7 @@ func GetDescByPath(desc *thrift.TypeDescriptor, path ...Path) (ret *thrift.TypeD
 		if ret == nil {
 			return nil, errNode(meta.ErrNotFound, "", err)
 		}
+		desc = ret
 	}
 	return
 }

--- a/thrift/generic/value_test.go
+++ b/thrift/generic/value_test.go
@@ -744,6 +744,27 @@ func TestUnsetByPath(t *testing.T) {
 	require.Equal(t, l-1, ll)
 }
 
+func TestGetDescByPathFailing(t *testing.T) {
+	// Assumes `exampleIDLPath` points to a valid Thrift file with the expected structure.
+	svc, err := thrift.NewDescritorFromPath(context.Background(), "../../testdata/idl/example2.thrift")
+	if err != nil {
+		panic(err)
+	}
+	desc := svc.Functions()["ExampleMethod"].Request().Struct().FieldByKey("req").Type()
+
+	// Define a path that traverses into a nested struct.
+	path := []Path{
+		NewPathFieldName("InnerBase"),
+		NewPathFieldName("Bool"),
+	}
+
+	// Attempt to get the descriptor for the nested field.
+	_, err = GetDescByPath(desc, path...)
+
+	// This assertion will fail with the buggy code.
+	require.NoError(t, err, "GetDescByPath should not fail for a valid path")
+}
+
 func TestSetByPath(t *testing.T) {
 	desc := getExampleDesc()
 	data := getExampleData()


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
fix

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
fix(thrift/generic): 修复 GetDescByPath 无法正确遍历嵌套结构的问题

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
The `GetDescByPath` function did not update its descriptor variable (`desc`) within the traversal loop. This caused it to always reference the top-level descriptor, leading to "unknown field" errors when attempting to access fields within nested structs. This PR fixes it by updating the descriptor at the end of each iteration. A new unit test is also added to verify the fix.

zh(optional):
`GetDescByPath` 函数在遍历循环中没有更新其描述符变量 (`desc`)。这导致它始终引用顶级描述符，在尝试访问嵌套结构体中的字段时会导致“未知字段”错误。此 PR 通过在每次迭代结束时更新描述符来修复此问题。还添加了一个新的单元测试来验证修复。


#### (Optional) Which issue(s) this PR fixes: https://github.com/cloudwego/dynamicgo/issues/109
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->